### PR TITLE
Add service support

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -23,7 +23,7 @@ module.exports = build;
  */
 
 function build (context) {
-	var dockerfile = format('FROM node:%s-onbuild', context.version);
+	var dockerfile = format('FROM node:%s', context.version);
 	var tmpPath = join(context.path, '.' + context.version + '.dockerfile');
 
 	return fs.writeFile(tmpPath, dockerfile)

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -28,5 +28,16 @@ function clean (context) {
 
 	var image = format('test-%s-%s', context.name, context.version);
 
-	return run('docker', ['rmi', image]).return(context);
+	return Promise.resolve(context.services)
+		.map(function (service) {
+			var serviceName = format('%s-%s-%s', service, context.name, context.version);
+
+			return run('docker', ['kill', serviceName]).then(function () {
+				return run('docker', ['rm', serviceName]);
+			});
+		})
+		.then(function () {
+			return run('docker', ['rmi', image]);
+		})
+		.return(context);
 }

--- a/lib/parse-config.js
+++ b/lib/parse-config.js
@@ -20,5 +20,8 @@ module.exports = parseConfig;
  */
 
 function parseConfig (path) {
-	return yaml.parse(fs.readFileSync(path, 'utf-8'));
+	var config = yaml.parse(fs.readFileSync(path, 'utf-8'));
+	config.services = [].concat(config.services || []);
+
+	return config;
 }

--- a/lib/pull-image.js
+++ b/lib/pull-image.js
@@ -20,8 +20,13 @@ module.exports = pullImage;
  * Pull docker image for a specific node version
  */
 
-function pullImage (context) {
-	var image = format('node:%s-onbuild', context.version);
+function pullImage (imageName, context) {
+	if (typeof imageName !== 'string') {
+		context = imageName;
+		imageName = 'node';
+	}
+
+	var image = format('%s:%s', imageName, context.version);
 
 	return run('docker', ['pull', image]).return(context);
 }

--- a/lib/service.js
+++ b/lib/service.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * Dependencies
+ */
+
+var format = require('util').format;
+var objectAssign = require('object-assign');
+
+var pullImage = require('./pull-image');
+var run = require('../util/run');
+
+
+/**
+ * Services
+ */
+
+var services = {
+	mongodb: {
+		host: 'db',
+		repository: 'mongo',
+		tag: 'latest'
+	}
+};
+
+
+/**
+ * Expose
+ */
+
+module.exports.start = startService;
+module.exports.pull = pullService;
+
+
+/**
+ * Pull the service
+ */
+
+function pullService (serviceName) {
+	var service = services[serviceName];
+
+	if (!startService) {
+		// TODO start custom image
+		throw new Error(serviceName + ' is not supported');
+	}
+
+	return pullImage(service.repository, { version: service.tag });
+}
+
+
+/**
+ * Start the service for a specific context
+ */
+
+function startService (serviceName, context) {
+	var service = services[serviceName];
+
+	var name = format('%s-%s-%s', serviceName, context.name, context.version);
+	var image = format('%s:%s', service.repository, service.tag);
+
+	return run('docker', ['run', '-d', '--name', name, image]).return(objectAssign(service, { name: serviceName }));
+}

--- a/lib/states.js
+++ b/lib/states.js
@@ -10,7 +10,8 @@ var states = {
 	cleaning: 2,
 	running: 3,
 	success: 4,
-	error: 5
+	error: 5,
+	preparing: 6
 };
 
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -4,8 +4,10 @@
  * Dependencies
  */
 
+var Promise = require('bluebird');
 var format = require('util').format;
 
+var service = require('./service');
 var run = require('../util/run');
 
 
@@ -21,13 +23,6 @@ module.exports = test;
  */
 
 function test (context) {
-	var image = format('test-%s-%s', context.name, context.version);
-
-	var args = [
-		'run',
-		'--rm'
-	];
-
 	// append default environment
 	// variables to arguments
 	var env = {
@@ -36,13 +31,36 @@ function test (context) {
 		CI: true
 	};
 
-	Object.keys(env).forEach(function (name) {
-		var arg = format('%s=%s', name, env[name]);
+	return Promise.resolve(context.services)
+		.map(function (serviceName) {
+			return service.start(serviceName, context);
+		})
+		.then(function (services) {
+			var image = format('test-%s-%s', context.name, context.version);
 
-		args.push('-e', arg);
-	});
+			var args = [
+				'run',
+				'--rm'
+			];
 
-	args.push(image, 'npm', 'test');
+			// expose environment variables
+			Object.keys(env).forEach(function (name) {
+				var arg = format('%s=%s', name, env[name]);
 
-	return run('docker', args).return(context);
+				args.push('-e', arg);
+			});
+
+			// expose services
+			services.forEach(function (service) {
+				var serviceName = format('%s-%s-%s', service.name, context.name, context.version);
+				var arg = format('%s:%s', serviceName, service.host);
+
+				args.push('--link', arg);
+			});
+
+			args.push(image, 'npm', 'test');
+
+			return run('docker', args).return(context);
+		})
+		.return(context);
 }

--- a/lib/update-state.js
+++ b/lib/update-state.js
@@ -11,7 +11,6 @@ var chalk = require('chalk');
 
 var states = require('./states');
 
-
 /**
  * Expose `update-state`
  */
@@ -29,6 +28,11 @@ function updateState (state) {
 		var icon;
 
 		var currentState = state[version];
+
+		if (currentState === states.preparing) {
+			icon = chalk.grey(figures.circleDotted);
+			message = chalk.grey('preparing');
+		}
 
 		if (currentState === states.downloading) {
 			message = chalk.grey('downloading base image');

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "log-update": "^1.0.1",
     "meow": "^3.4.2",
     "mz": "^2.0.0",
+    "object-assign": "^4.0.1",
     "stable-node-version": "^1.0.0",
     "text-table": "^0.2.0",
     "yamljs": "^0.2.4"


### PR DESCRIPTION
Created a first version of the service support. The only service supported at the moment is `mongodb`. If we think the implementation is good, I will add support for others as well.

This PR is not directly meant to be merged, rather to provide feedback and think together on how we can improve this.

**note 1**: `travis` exposes [mongodb](http://docs.travis-ci.com/user/database-setup/#MongoDB) at the `127.0.0.1`. This seems not possible when linking containers, but not sure, maybe there is a way. So at the moment, mongodb is exposed as `db` host.

**note 2**: I used the `latest` version of `mongodb`, but I believe `travis` is exposes `2.4.x` or something (which is a shame off course). We should definitely use the same version as `travis`. If people want to use a later version, they can in the future when we integrate custom services.

**note 3**: I'm not very familiar with `bluebird`, so some things might be done differently. Happy to receive feedback on that as well.
