### PR TITLE
allows for v- style node version prefixes

### DIFF
--- a/lib/get-versions.js
+++ b/lib/get-versions.js
@@ -3,7 +3,7 @@
 const stableVersion = require('stable-node-version');
 const pMap = require('p-map');
 
-const re = /^v(\d+\.)?(\d+\.)?(\*|\d+)$/;
+const versionRegex = /^v(\d+\.)?(\d+\.)?(\*|\d+)$/;
 
 module.exports = config => {
 	const versions = config.node_js || ['stable'];
@@ -12,8 +12,9 @@ module.exports = config => {
 		if (version === 'stable' || version === 'node') {
 			return stableVersion();
 		}
-		if (re.test(version)) {
-			return version.split('').shift().join('');
+
+		if (versionRegex.test(version)) {
+			return version.slice(1);
 		}
 
 		return version;

--- a/lib/get-versions.js
+++ b/lib/get-versions.js
@@ -3,7 +3,7 @@
 const stableVersion = require('stable-node-version');
 const pMap = require('p-map');
 
-const re = /v(\d)/;
+const re = /^v(\d+\.)?(\d+\.)?(\*|\d+)$/;
 
 module.exports = config => {
 	const versions = config.node_js || ['stable'];

--- a/lib/get-versions.js
+++ b/lib/get-versions.js
@@ -3,12 +3,17 @@
 const stableVersion = require('stable-node-version');
 const pMap = require('p-map');
 
+const re = /v(\d)/;
+
 module.exports = config => {
 	const versions = config.node_js || ['stable'];
 
 	return pMap(versions, version => {
 		if (version === 'stable' || version === 'node') {
 			return stableVersion();
+		}
+		if (re.test(version)) {
+			return version.split('').shift().join('');
 		}
 
 		return version;


### PR DESCRIPTION
Travis allows Node versions to be specified by 'v6', etc. This should allow them to be specified as such, passed internally without the 'v' prefix, so as to eliminate the need for [this sort of silly thing](https://github.com/edm00se/emoji-transmogrifier/commit/27caa4baacf210266a2e6088166ecb84cc0093f8).