### PR TITLE
feat: specify the main field of the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "repository": "vadimdemedes/trevor",
   "author": "Vadim Demedes <vdemedes@gmail.com",
+  "main": "./lib/main.js",
   "engines": {
     "node": ">= 6"
   },


### PR DESCRIPTION
so, we can use in node modules, not only in CLI.

```javascript
const trevor = require('trevor');

trevor({ cwd: '/path/to/your/project/contain/travis/file' });
```
