### PR TITLE
handle lts/<codename> and lts/* keywords

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -10,12 +10,11 @@ const writeFile = pify(fs.writeFile);
 module.exports = context => {
 	const dockerfile = [
 		`FROM node:${context.version}`,
-		'RUN mkdir -p /usr/src/app',
 		'WORKDIR /usr/src/app',
-		'COPY package.json /usr/src/app/',
+		'COPY package.json .',
 		'RUN npm install && npm cache clean --force',
-		'COPY . /usr/src/app',
-		'CMD [ "npm", "start" ]'
+		'COPY . .',
+		'CMD ["npm", "start"]'
 	].join('\n');
 
 	const tmpPath = path.join(context.cwd, `.${context.version}.dockerfile`);

--- a/lib/build.js
+++ b/lib/build.js
@@ -11,9 +11,11 @@ module.exports = context => {
 	const dockerfile = [
 		`FROM node:${context.version}`,
 		'WORKDIR /usr/src/app',
-		'COPY package.json .',
-		'RUN npm install && npm cache clean --force',
-		'COPY . .',
+		'ONBUILD ARG NODE_ENV',
+		'ONBUILD ENV NODE_ENV $NODE_ENV',
+		'ONBUILD COPY package.json .',
+		'ONBUILD RUN npm install && npm cache clean --force',
+		'ONBUILD COPY . .',
 		'CMD ["npm", "start"]'
 	].join('\n');
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -14,7 +14,7 @@ module.exports = context => {
 		'COPY package.json .',
 		'RUN npm install && npm cache clean --force',
 		'COPY . .',
-		'CMD ["npm", "start"]'
+		'CMD ["npm", "test"]'
 	].join('\n');
 
 	const tmpPath = path.join(context.cwd, `.${context.version}.dockerfile`);

--- a/lib/build.js
+++ b/lib/build.js
@@ -8,7 +8,7 @@ const pify = require('pify');
 const writeFile = pify(fs.writeFile);
 
 module.exports = context => {
-	const dockerfile = `FROM node:${context.version}-onbuild`;
+	const dockerfile = `FROM node:${context.version}`;
 	const tmpPath = path.join(context.cwd, `.${context.version}.dockerfile`);
 
 	const image = `test-${context.name}-${context.version}`;

--- a/lib/build.js
+++ b/lib/build.js
@@ -14,7 +14,7 @@ module.exports = context => {
 		'COPY package.json .',
 		'RUN npm install && npm cache clean --force',
 		'COPY . .',
-		'CMD ["npm", "test"]'
+		'CMD ["npm", "start"]'
 	].join('\n');
 
 	const tmpPath = path.join(context.cwd, `.${context.version}.dockerfile`);

--- a/lib/build.js
+++ b/lib/build.js
@@ -8,7 +8,16 @@ const pify = require('pify');
 const writeFile = pify(fs.writeFile);
 
 module.exports = context => {
-	const dockerfile = `FROM node:${context.version}`;
+	const dockerfile = [
+		`FROM node:${context.version}`,
+		'RUN mkdir -p /usr/src/app',
+		'WORKDIR /usr/src/app',
+		'COPY package.json /usr/src/app/',
+		'RUN npm install && npm cache clean --force',
+		'COPY . /usr/src/app',
+		'CMD [ "npm", "start" ]'
+	].join('\n');
+
 	const tmpPath = path.join(context.cwd, `.${context.version}.dockerfile`);
 
 	const image = `test-${context.name}-${context.version}`;

--- a/lib/build.js
+++ b/lib/build.js
@@ -11,11 +11,11 @@ module.exports = context => {
 	const dockerfile = [
 		`FROM node:${context.version}`,
 		'WORKDIR /usr/src/app',
-		'ONBUILD ARG NODE_ENV',
-		'ONBUILD ENV NODE_ENV $NODE_ENV',
-		'ONBUILD COPY package.json .',
-		'ONBUILD RUN npm install && npm cache clean --force',
-		'ONBUILD COPY . .',
+		'ARG NODE_ENV',
+		'ENV NODE_ENV $NODE_ENV',
+		'COPY package.json .',
+		'RUN npm install',
+		'COPY . .',
 		'CMD ["npm", "start"]'
 	].join('\n');
 

--- a/lib/get-versions.js
+++ b/lib/get-versions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stableVersion = require('stable-node-version');
+const fetchRelease = require('fetch-node-release');
 const pMap = require('p-map');
 
 const versionRegex = /^v(\d+\.)?(\d+\.)?(\*|\d+)$/;
@@ -9,8 +9,8 @@ module.exports = config => {
 	const versions = config.node_js || ['stable'];
 
 	return pMap(versions, version => {
-		if (version === 'stable' || version === 'node') {
-			return stableVersion();
+		if (fetchRelease.regexp.test(version)) {
+			return fetchRelease(version);
 		}
 
 		if (versionRegex.test(version)) {

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -3,7 +3,7 @@
 const exec = require('execa');
 
 module.exports = context => {
-	const image = `node:${context.version}-onbuild`;
+	const image = `node:${context.version}`;
 
 	return exec('docker', ['pull', image]).then(() => context);
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "chalk": "^1.1.3",
     "cp-file": "^4.1.1",
     "execa": "^0.6.0",
+    "fetch-node-release": "^1.0.0",
     "figures": "^2.0.0",
     "indent-string": "^3.1.0",
     "load-json-file": "^2.0.0",
@@ -30,7 +31,6 @@
     "p-map": "^1.1.1",
     "p-tap": "^1.0.0",
     "pify": "^2.3.0",
-    "stable-node-version": "^1.0.0",
     "text-table": "^0.2.0",
     "yamljs": "^0.2.8"
   },


### PR DESCRIPTION
This PR is based on #68 and in addition replaces the stable-node-version package with fetch-node-release that handles parsing the nodejs dist pages for specific lts codename as well as lts/* for the latest lts in general.

Fixes #61 
Fixes #73
Fixes #67 
Closes #68 